### PR TITLE
Replaced U+2010 (e2 80 90 HYPHEN) by a plain dash

### DIFF
--- a/doc/protocols.texi
+++ b/doc/protocols.texi
@@ -155,7 +155,7 @@ be seekable, so they will fail with the pipe output protocol.
 
 Real-Time Messaging Protocol.
 
-The Real-Time Messaging Protocol (RTMP) is used for streaming multime‐
+The Real-Time Messaging Protocol (RTMP) is used for streaming multime-
 dia content across a TCP/IP network.
 
 The required syntax is:


### PR DESCRIPTION
Without that change, "make" fails on my Debian system when building the doc as a character outside of the ASCII range is encountered.

A better long-term solution would be to specify the UTF-8 encoding for the texi input files -- but this is beyond my knowledge.
